### PR TITLE
Add Shift+click force-update shortcut

### DIFF
--- a/UpdateChecker.cs
+++ b/UpdateChecker.cs
@@ -23,7 +23,7 @@ namespace MasselGUARD
     {
         private const string TagsApiUrl     = "https://api.github.com/repos/masselink/MasselGUARD/tags";
         private const string ReleasesApiUrl = "https://api.github.com/repos/masselink/MasselGUARD/releases";
-        private const string CurrentVersion = "3.0.1.2605272119";  // updated by build.bat — keep in sync with AppTitle
+        private const string CurrentVersion = "3.0.1.2605272131";  // updated by build.bat — keep in sync with AppTitle
 
         // ── Public: silent background check (called on startup) ──────────────
         public static async Task CheckAsync(AppConfig cfg, Action saveConfig,

--- a/Views/SettingsWindow.xaml.cs
+++ b/Views/SettingsWindow.xaml.cs
@@ -1442,6 +1442,11 @@ namespace MasselGUARD.Views
 
         private async void CheckUpdate_Click(object sender, RoutedEventArgs e)
         {
+            // Shift+click: force-install whatever is on GitHub, bypassing version check.
+            // Developer shortcut for testing the update pipeline.
+            bool forceUpdate = (System.Windows.Input.Keyboard.Modifiers
+                                & System.Windows.Input.ModifierKeys.Shift) != 0;
+
             if (CheckUpdateBtn != null)
             {
                 CheckUpdateBtn.IsEnabled = false;
@@ -1457,6 +1462,17 @@ namespace MasselGUARD.Views
             _latestRelease            = latest;
             _updateCheckedThisSession = true;
             RefreshUpdateState();
+
+            if (forceUpdate && latest != null)
+            {
+                // Force mode: start update unconditionally (even if local build is newer).
+                if (_main.ShowThemedYesNo(
+                    $"Force-install {latest.TagName}?\n\nThis will overwrite your current build. Use this only to test the update pipeline.",
+                    "MasselGUARD — Force Update"))
+                    await StartUpdateAsync(latest);
+                return;
+            }
+
             if (latest != null && UpdateChecker.IsNewerVersion(latest.TagName))
             {
                 var current = UpdateChecker.CurrentVersionString;


### PR DESCRIPTION
Bump CurrentVersion to 3.0.1.2605272131 and add a developer shortcut to force-install the latest GitHub release from the Settings window. Holding Shift while clicking "Check for updates" sets a forceUpdate flag that bypasses the version check, prompts the user for confirmation, and starts the update (used to test the update pipeline). Changes in UpdateChecker.cs and Views/SettingsWindow.xaml.cs.