### PR TITLE
Remove WHATSNEW copy and bump version

### DIFF
--- a/BUILD.bat
+++ b/BUILD.bat
@@ -98,14 +98,6 @@ if exist "%~dp0theme" (
 )
 echo.
 
-rem ── Step 3b: copy WHATSNEW.md into dist ─────────────────────────────────────
-if exist "%~dp0docs\WHATSNEW.md" (
-    copy /y "%~dp0docs\WHATSNEW.md" "%~dp0dist\WHATSNEW.md" >nul
-) else (
-    echo  WARNING: docs\WHATSNEW.md not found -- skipped.
-)
-echo.
-
 rem ── Step 4: copy DLLs from wireguard-deps ────────────────────────────────────
 echo  -------------------------------------------------------
 echo   Copying tunnel DLLs from wireguard-deps\...
@@ -138,7 +130,6 @@ echo   BUILD SUCCESSFUL
 echo  ==========================================
 echo.
 echo   dist\MasselGUARD.exe
-echo   dist\WHATSNEW.md
 echo   dist\lang\
 echo   dist\theme\
 if "!DLL_OK!"=="1" (

--- a/UpdateChecker.cs
+++ b/UpdateChecker.cs
@@ -23,7 +23,7 @@ namespace MasselGUARD
     {
         private const string TagsApiUrl     = "https://api.github.com/repos/masselink/MasselGUARD/tags";
         private const string ReleasesApiUrl = "https://api.github.com/repos/masselink/MasselGUARD/releases";
-        private const string CurrentVersion = "3.1.0.2605301815";  // updated by build.bat — keep in sync with AppTitle
+        private const string CurrentVersion = "3.1.0.2605301856";  // updated by build.bat — keep in sync with AppTitle
 
         // ── Public: silent background check (called on startup) ──────────────
         public static async Task CheckAsync(AppConfig cfg, Action saveConfig,


### PR DESCRIPTION
Remove the BUILD.bat step that copied docs\WHATSNEW.md into dist and the corresponding listing in the build output. Also update the CurrentVersion constant in UpdateChecker.cs from 3.1.0.2605301815 to 3.1.0.2605301856 to reflect the new build version.